### PR TITLE
footnoteを修飾したり、リンクを貼ったりできるように。

### DIFF
--- a/bin/md2review
+++ b/bin/md2review
@@ -21,7 +21,7 @@ parse_extensions = {}
 parse_extensions[:tables] = true
 parse_extensions[:strikethrough] = true
 parse_extensions[:fenced_code_blocks] = true
-
+parse_extensions[:footnotes] = true
 
 renderer = Redcarpet::Render::ReVIEW
 

--- a/lib/redcarpet/render/review.rb
+++ b/lib/redcarpet/render/review.rb
@@ -181,7 +181,7 @@ module Redcarpet
       end
 
       def footnote_def(text,number)
-        "\n//footnote[#{number}][#{escape_inline(text).strip}]\n"
+        "\n//footnote[#{number}][#{text.strip}]\n"
       end
 
     end

--- a/test/review_test.rb
+++ b/test/review_test.rb
@@ -74,7 +74,7 @@ class ReVIEWTest < Test::Unit::TestCase
   end
 
   def test_footnote
-    rd = render_with({:footnotes=>true}, "これは脚注付き[^1]の段落です。\n\n\n[^1]: そして、これが脚注です。\n")
-    assert_equal %Q|\n\nこれは脚注付き@<fn>{1}の段落です。\n\n\n//footnote[1][そして、これが脚注です。]\n|, rd
+    rd = render_with({:footnotes=>true}, "これは*脚注*付き[^1]の段落です。\n\n\n[^1]: そして、これが脚注です。\n")
+    assert_equal %Q|\n\nこれは@<b>{脚注}付き@<fn>{1}の段落です。\n\n\n//footnote[1][そして、これが脚注です。]\n|, rd
   end
 end


### PR DESCRIPTION
footnoteにリンクを貼ることはよくあると思うのでエスケープしないようにしました。
