### PR TITLE
convert link to footnote for printing

### DIFF
--- a/bin/md2review
+++ b/bin/md2review
@@ -17,6 +17,7 @@ require 'redcarpet'
 require 'redcarpet/render/review'
 
 render_extensions = {}
+render_extensions[:link_as_footnote] = false
 parse_extensions = {}
 parse_extensions[:tables] = true
 parse_extensions[:strikethrough] = true


### PR DESCRIPTION
印刷用にlinkタグをfootnoteに変換するオプション追加
オプション名は要検討
