### PR TITLE
Remove Re:VIEW inline markups from href content

### DIFF
--- a/lib/redcarpet/render/review.rb
+++ b/lib/redcarpet/render/review.rb
@@ -140,7 +140,8 @@ module Redcarpet
           @links[key] ||= link
           footnotes(content) + footnote_ref(key)
         else
-          "@<href>{#{escape_href(link)},#{escape_inline(content)}}"
+          content = escape_inline(remove_inline_markups(content))
+          "@<href>{#{escape_href(link)},#{content}}"
         end
       end
 
@@ -232,6 +233,10 @@ module Redcarpet
 
       def postprocess(text)
         text + @links.map { |key, link| footnote_def(link, key) }.join
+      end
+
+      def remove_inline_markups(text)
+        text.gsub(/@<(?:b|strong|tt)>{([^}]*)}/, '\1')
       end
     end
   end

--- a/test/review_test.rb
+++ b/test/review_test.rb
@@ -42,6 +42,18 @@ class ReVIEWTest < Test::Unit::TestCase
     assert_equal %Q|\n\naaa foo@<fn>{3ccd7167b80081c737b749ad1c27dcdc}, bar@<fn>{9dcab303478e38d32d83ae19daaea9f6}, foo2@<fn>{3ccd7167b80081c737b749ad1c27dcdc}\n\n\n//footnote[3ccd7167b80081c737b749ad1c27dcdc][http://example.jp/foo]\n\n//footnote[9dcab303478e38d32d83ae19daaea9f6][http://example.jp/bar]\n|, rd
   end
 
+  def test_href_with_emphasised_anchor
+    assert_equal "\n\n@<href>{http://exmaple.com/,example}\n\n", @markdown.render("[*example*](http://exmaple.com/)")
+  end
+
+  def test_href_with_double_emphasised_anchor
+    assert_equal "\n\n@<href>{http://exmaple.com/,example}\n\n", @markdown.render("[**example**](http://exmaple.com/)")
+  end
+
+  def test_href_with_codespan_anchor
+    assert_equal "\n\n@<href>{http://exmaple.com/,example}\n\n", @markdown.render("[`example`](http://exmaple.com/)")
+  end
+
   def test_header
     assert_respond_to @markdown, :render
     assert_equal "\n= AAA\n\n\nBBB\n\n\n== ccc\n\n\nddd\n\n", @markdown.render("#AAA\nBBB\n\n##ccc\n\nddd\n")


### PR DESCRIPTION
以下のようなMarkdownをmd2reviewで変換すると

```markdown
[*example*](http://example.com/)
```

以下のようなReVIEWが出力されます。

```
@<href>{http://example.com/,@<b>{example\}}
```

これをreviewでコンパイルすると以下のようなエラーが出ます。

> error: `@\<xxx\>' seen but is not valid inline op: @\<href\>{http://example.com/, @\<b\>{example\\}}

Markdown中で`**`や`*`で強調した文や\`で囲ったコードにリンクを張ることはよくあります。
記法の問題でコンパイルエラーになるよりは、見た目が変わったとしても取り除いてしまってコンパイルが通る方が嬉しいのでlink中に`@<b>` / `@<strong>` / `@<tt>`がある場合取り除く処理を追加しました :scissors: