### PR TITLE
Remove spaces before image block

### DIFF
--- a/lib/redcarpet/render/review.rb
+++ b/lib/redcarpet/render/review.rb
@@ -231,6 +231,7 @@ module Redcarpet
       end
 
       def postprocess(text)
+        text = text.gsub(%r|^[ \t]+(//image\[[^\]]+\]\[[^\]]+\]{$\n^//})|, '\1')
         text + @links.map { |key, link| footnote_def(link, key) }.join
       end
     end

--- a/test/review_test.rb
+++ b/test/review_test.rb
@@ -67,6 +67,10 @@ class ReVIEWTest < Test::Unit::TestCase
     assert_equal "\n\n//image[image][test]{\n//}\n\n\n", @markdown.render("![test](path/to/image.jpg)\n")
   end
 
+  def test_indented_image
+    assert_equal "\n\n//image[image][test]{\n//}\n\n\n", @markdown.render(" ![test](path/to/image.jpg)\n")
+  end
+
   def test_indepimage
     rev = render_with({}, "![test](path/to/image.jpg)\n",{:disable_image_caption => true})
     assert_equal "\n\n//indepimage[image]\n\n\n", rev


### PR DESCRIPTION
以下のような画像の前に空白があるMarkdownを変換した際

```
 ![test](path/to/image.jpg)
```

ReVIEWに変換すると以下のようになる。

```
 //image[image][test]{
//}
```

先頭に空白が含まれていると以下のようなエラーが出てしまうため、
postprocessで図のタグの直前の空白を削除するようにした

> error: block end seen but not opened