### PR TITLE
emphasis中にリンクがある場合@<href>の前後を@<b>でマークアップし挟み込むようにした

### DIFF
--- a/lib/redcarpet/render/review.rb
+++ b/lib/redcarpet/render/review.rb
@@ -149,7 +149,7 @@ module Redcarpet
       end
 
       def emphasis(text)
-        "@<b>{#{escape_inline(text)}}"
+        sandwitch_link('b', text)
       end
 
       def strikethrough(text)
@@ -232,6 +232,16 @@ module Redcarpet
 
       def postprocess(text)
         text + @links.map { |key, link| footnote_def(link, key) }.join
+      end
+
+      def sandwitch_link(op, text)
+        head, match, tail = text.partition(/@<href>{(?:\\,|[^}])*}/)
+
+        if match.empty? && tail.empty?
+          return "@<#{op}>{#{escape_inline(text)}}"
+        end
+
+        sandwitch_link(op, head) + match + sandwitch_link(op, tail)
       end
     end
   end

--- a/test/review_test.rb
+++ b/test/review_test.rb
@@ -42,6 +42,11 @@ class ReVIEWTest < Test::Unit::TestCase
     assert_equal %Q|\n\naaa foo@<fn>{3ccd7167b80081c737b749ad1c27dcdc}, bar@<fn>{9dcab303478e38d32d83ae19daaea9f6}, foo2@<fn>{3ccd7167b80081c737b749ad1c27dcdc}\n\n\n//footnote[3ccd7167b80081c737b749ad1c27dcdc][http://example.jp/foo]\n\n//footnote[9dcab303478e38d32d83ae19daaea9f6][http://example.jp/bar]\n|, rd
   end
 
+  def test_emphasis_with_href
+    assert_respond_to @markdown, :render
+    assert_equal "\n\n@<b>{{hello\\} }@<href>{http://exmaple.com/foo\\,bar,example}@<b>{ world}\n\n", @markdown.render("*{hello} [example](http://exmaple.com/foo,bar) world*")
+  end
+
   def test_header
     assert_respond_to @markdown, :render
     assert_equal "\n= AAA\n\n\nBBB\n\n\n== ccc\n\n\nddd\n\n", @markdown.render("#AAA\nBBB\n\n##ccc\n\nddd\n")


### PR DESCRIPTION
```
*例えば[このような](http://example.com/)マークダウン*
```

上記のようなMarkdownを変換した際に、@\<b\>の中に@\<href\>が入れ子になってし
まい以下のようなエラーが発生するため

> error: `@\<xxx\>' seen but is not valid inline op