### PR TITLE
support --render-table-caption option

### DIFF
--- a/lib/redcarpet/render/review.rb
+++ b/lib/redcarpet/render/review.rb
@@ -16,6 +16,8 @@ module Redcarpet
         end
         @links = {}
         @cmd = render_extensions[:enable_cmd]
+        @support_table_caption = render_extensions[:table_caption]
+        @table_caption = nil
       end
 
       def normal_text(text)
@@ -102,7 +104,12 @@ module Redcarpet
           header_text = "#{header}-----------------\n"
         end
         body.chomp!
-        "//table[#{table_id()}][]{\n#{header_text}#{body}\n//}\n"
+        caption = nil
+        if @table_caption
+          caption = @table_caption.strip
+          @table_caption = nil
+        end
+        "//table[#{table_id()}][#{caption}]{\n#{header_text}#{body}\n//}\n"
       end
 
       def table_row(content)
@@ -162,7 +169,12 @@ module Redcarpet
       end
 
       def paragraph(text)
-        "\n\n#{text}\n\n"
+        if @support_table_caption && text =~ /\ATable:(.*)\z/
+          @table_caption = $1  ## and no output line
+          ""
+        else
+          "\n\n#{text}\n\n"
+        end
       end
 
       def list(content, list_type)

--- a/test/review_test.rb
+++ b/test/review_test.rb
@@ -118,6 +118,28 @@ class ReVIEWTest < Test::Unit::TestCase
     assert_equal "//table[tbl1][]{\na\tb\tc\n-----------------\nA\tB\tC\n.\tB\tC\n..A\tB\tC\n//}\n", rd
   end
 
+  def test_table_with_caption
+    rd = render_with({:tables => true}, <<-EOB, {:table_caption => true})
+
+Table: caption test
+
+| a  |  b |  c |
+|----|----|----|
+| A  | B  | C  |
+|    | B  |  C |
+| .A | B  |  C |
+    EOB
+    assert_equal <<-EOB, rd
+//table[tbl1][caption test]{
+a\tb\tc
+-----------------
+A\tB\tC
+.\tB\tC
+..A\tB\tC
+//}
+EOB
+  end
+
   def test_code_fence_with_caption
     rd = render_with({:fenced_code_blocks => true}, %Q[~~~ {caption="test"}\ndef foo\n  p "test"\nend\n~~~\n])
     assert_equal %Q[\n//emlist[test]{\ndef foo\n  p "test"\nend\n//}\n], rd


### PR DESCRIPTION
ex.

```markdown
Table: caption sample

|aaa|bbbb|cccc|
|---|:---|---:|
|123|234|456|
|123|234|456|
```

This option is compatible with Pandoc (but should be in front of table and not support short option only `: foobar`).