### PR TITLE
Fix "literal string will be frozen in the future" warnings

### DIFF
--- a/lib/redcarpet/render/review.rb
+++ b/lib/redcarpet/render/review.rb
@@ -35,7 +35,7 @@ module Redcarpet
         counter = -1
         if @math
           while %r|\$\$(.+?)\$\$| =~ text
-            text.sub!(%r|\$\$(.+?)\$\$|) do
+            text = text.sub(%r|\$\$(.+?)\$\$|) do
               counter += 1
               @math_buf[counter] = $1
               "〓MATH:#{counter}:〓"
@@ -112,7 +112,7 @@ module Redcarpet
       end
 
       def header(title, level, anchor="")
-        buf = ""
+        buf = +""
         if /\s+(\{.*?\})\s*$/ =~ title
           buf << "\n#@# header_attribute: #{$1}"
           title = $`
@@ -230,7 +230,7 @@ module Redcarpet
       end
 
       def list(content, list_type)
-        ret = ""
+        ret = +""
         content.each_line do |item|
           case list_type
           when :ordered


### PR DESCRIPTION
Currently, `md2review` causes "warning: literal string will be frozen in the future" warnings. The following is the partial.

```
md2review/lib/redcarpet/render/review.rb:123: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
md2review/lib/redcarpet/render/review.rb:125: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
md2review/lib/redcarpet/render/review.rb:127: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
md2review/lib/redcarpet/render/review.rb:129: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

This PR fixes those.