### PR TITLE
Fix table not converted when footnote definition precedes it

### DIFF
--- a/lib/redcarpet/render/review.rb
+++ b/lib/redcarpet/render/review.rb
@@ -42,6 +42,9 @@ module Redcarpet
             end
           end
         end
+        text = text.gsub(/((?:^\[\^[^\]]+\]:.*(?:\n[ \t]{4}.*)*\n)+)(\n+)((?:\|[^\n]*\n)+)/) do
+          "\n#{$2}#{$3}#{$1}"
+        end
         text
       end
 

--- a/test/review_test.rb
+++ b/test/review_test.rb
@@ -270,6 +270,11 @@ EOB
     assert_equal %Q|\n\nこれは@<b>{脚注}付き@<fn>{1}の段落です。\n\n\n//footnote[1][そして、これが脚注です。]\n|, rd
   end
 
+  def test_table_after_footnote_def
+    rd = render_with({footnotes: true, tables: true}, "foo[^bar], baz.\n[^bar]: https://example.com/\n\n\n| A | B |\n| --- | --- |\n| foo | bar |\n")
+    assert_equal %Q[\n\nfoo@<fn>{1}, baz.\n\n//table[tbl1][]{\nA\tB\n-----------------\nfoo\tbar\n//}\n\n//footnote[1][https://example.com/]\n], rd
+  end
+
   def test_autolink
     rd = render_with({autolink: true}, "リンクの[テスト](http://example.jp/test)です。\nhttp://example.jp/test2/\n")
     assert_equal %Q[\n\nリンクの@<href>{http://example.jp/test,テスト}です。\n@<href>{http://example.jp/test2/}\n\n], rd


### PR DESCRIPTION
When a document contains a footnote definition followed by a table, redcarpet failed to recognize the table and output it as raw text.

Reproduce case:

```
  foo[^bar], baz.
  [^bar]: https://example.com/

  | A | B |
  | --- | --- |
  | foo | bar |
```

Fix by reordering the footnote definition(s) and the following table in `preprocess`, so redcarpet correctly parses the table as a block element.